### PR TITLE
Variable dialog width for MRProgressOverlayViewModeIndeterminateSmall and MRProgressOverlayViewModeIndeterminateSmallDefault to keep titleLableText as one line as possible

### DIFF
--- a/src/Components/MRProgressOverlayView.h
+++ b/src/Components/MRProgressOverlayView.h
@@ -8,8 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
-
-typedef enum {
+/** (MRProgressOverlayViewMode) */
+typedef NS_ENUM(NSUInteger, MRProgressOverlayViewMode){
     /** Progress is shown using a large round activity indicator view. (MRActivityIndicatorView) This is the default. */
     MRProgressOverlayViewModeIndeterminate,
     /** Progress is shown using a round, pie-chart like, progress view. (MRCircularProgressView) */
@@ -26,7 +26,7 @@ typedef enum {
     MRProgressOverlayViewModeCross,
     /** Shows a custom view. (UIView) */
     MRProgressOverlayViewModeCustom,
-} MRProgressOverlayViewMode;
+};
 
 
 /**

--- a/src/Components/MRProgressOverlayView.m
+++ b/src/Components/MRProgressOverlayView.m
@@ -519,14 +519,14 @@ static void *MRProgressOverlayViewObservationContext = &MRProgressOverlayViewObs
     
     const CGFloat dialogPadding = 15;
     const CGFloat modePadding = 30;
-    
-    CGFloat dialogWidth = 150;
+    const CGFloat dialogMargin = 10;
+    const CGFloat dialogMinWidth = 150;
+    const BOOL hasSmallIndicator = self.mode == MRProgressOverlayViewModeIndeterminateSmall
+    || self.mode == MRProgressOverlayViewModeIndeterminateSmallDefault;
+    CGFloat dialogWidth = hasSmallIndicator ? CGRectGetWidth(bounds) - dialogMargin * 2 : dialogMinWidth;
     if (self.mode == MRProgressOverlayViewModeCustom) {
         dialogWidth = self.modeView.frame.size.width + 2*modePadding;
     }
-    
-    const BOOL hasSmallIndicator = self.mode == MRProgressOverlayViewModeIndeterminateSmall
-                                || self.mode == MRProgressOverlayViewModeIndeterminateSmallDefault;
     
     CGFloat y = 7;
     
@@ -554,18 +554,27 @@ static void *MRProgressOverlayViewObservationContext = &MRProgressOverlayViewObs
                                                                            context:nil];
         CGSize titleLabelSize = CGSizeMake(MRCGFloatCeil(boundingRect.size.width),
                                            MRCGFloatCeil(boundingRect.size.height));
-        
-        CGPoint titleLabelOrigin = CGPointMake(titleLabelMinX + (titleLabelMaxWidth - titleLabelSize.width) / 2.0f, y);
-        CGRect titleLabelFrame = {titleLabelOrigin, titleLabelSize};
-        self.titleLabel.frame = titleLabelFrame;
-        
+        CGPoint titleLabelOrigin;
         if (hasSmallIndicator) {
+            CGFloat titleLabelMinWidth = dialogMinWidth - 2*dialogPadding - offset;
+            if (titleLabelSize.width > titleLabelMinWidth) {
+                dialogWidth = titleLabelSize.width + offset + 2* dialogPadding;
+                titleLabelOrigin = CGPointMake(titleLabelMinX, y);
+            } else {
+                dialogWidth = dialogMinWidth;
+                titleLabelOrigin = CGPointMake(titleLabelMinX + (titleLabelMinWidth - titleLabelSize.width) / 2.0f, y);
+            }
+            
             CGPoint modeViewOrigin = CGPointMake(titleLabelOrigin.x - offset,
                                                  y + (titleLabelSize.height - modeViewSize.height) / 2.0f);
             CGRect modeViewFrame = {modeViewOrigin, modeViewSize};
             self.modeView.frame = modeViewFrame;
+        } else {
+            titleLabelOrigin = CGPointMake(titleLabelMinX + (titleLabelMaxWidth - titleLabelSize.width) / 2.0f, y);
         }
         
+        CGRect titleLabelFrame = {titleLabelOrigin, titleLabelSize};
+        self.titleLabel.frame = titleLabelFrame;
         y += CGRectGetMaxY(titleLabelFrame);
     }
     


### PR DESCRIPTION
MRProgressOverlayViewModeIndeterminateSmall and MRProgressOverlayViewModeIndeterminateSmallDefault mode are used with one word commonly, the fixed width 150 point is not long enough for some common word just as “Searching...” or “Preparing...” for example.
