### PR TITLE
Add a path to macports for appledoc

### DIFF
--- a/bin/build_appledoc.sh
+++ b/bin/build_appledoc.sh
@@ -4,7 +4,7 @@ _PATH=$PATH
 
 which appledoc &> /dev/null
 if [[ $? == 1 ]]; then
-	PATH=$PATH:/usr/local/bin
+	PATH=$PATH:/usr/local/bin:/opt/local/bin
 	which appledoc &> /dev/null
 	if [[ $? == 1 ]]; then
 		echo "Appledoc was not found. Try installing it by 'brew install appledoc'."


### PR DESCRIPTION
I prefer to use MacPorts but the shell script generating appledoc did not search /opt/local/bin.
That causes a compile error.
I added a search path to MacPorts bin directory.
