### PR TITLE
Set alpha depending on progress at completion time

### DIFF
--- a/src/Components/MRNavigationBarProgressView.m
+++ b/src/Components/MRNavigationBarProgressView.m
@@ -207,7 +207,7 @@ static void *MRNavigationBarProgressViewObservationContext = &MRNavigationBarPro
         
         void(^completion)(BOOL) = ^(BOOL finished){
             [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
-                self.progressView.alpha = progress >= 1 ? 0 : 1;
+                self.progressView.alpha = self.progress >= 1 ? 0 : 1;
             } completion:nil];
         };
         


### PR DESCRIPTION
Otherwise, there's a race condition where alpha will be set to 0, 1, and then 0 again if setProgress:animated: is called in quick enough succession (basically, within the animation duration).
