### PR TITLE
Fix MRActivityIndicatorView notification methods

### DIFF
--- a/src/Components/MRActivityIndicatorView.m
+++ b/src/Components/MRActivityIndicatorView.m
@@ -79,11 +79,11 @@ NSString *const MRActivityIndicatorViewSpinAnimationKey = @"MRActivityIndicatorV
     [center removeObserver:self];
 }
 
-- (void)applicationDidEnterBackground:(NSNotificationCenter *)note {
+- (void)applicationDidEnterBackground:(NSNotification *)note {
     [self removeAnimation];
 }
 
-- (void)applicationWillEnterForeground:(NSNotificationCenter *)note {
+- (void)applicationWillEnterForeground:(NSNotification *)note {
     if (self.isAnimating) {
         [self addAnimation];
     }


### PR DESCRIPTION
These should take objects of type NSNotification rather than NSNotificationCenter. The arguments are not currently used so it doesn't matter all that much, however it is still an incorrect cast.
