### PR TITLE
Inset progress line by half its width

### DIFF
--- a/src/Components/MRCircularProgressView.m
+++ b/src/Components/MRCircularProgressView.m
@@ -136,8 +136,9 @@ static NSString *const MRCircularProgressViewProgressAnimationKey = @"MRCircular
     
     CGFloat width = self.frame.size.width;
     CGFloat borderWidth = self.layer.borderWidth;
+    CGFloat lineWidth = self.lineWidth;
     return [UIBezierPath bezierPathWithArcCenter:CGPointMake(width/2.0f, width/2.0f)
-                                          radius:width/2.0f - borderWidth
+                                          radius:width/2.0f - lineWidth/2.0f - borderWidth/2.0f
                                       startAngle:startAngle
                                         endAngle:endAngle
                                        clockwise:YES];


### PR DESCRIPTION
I found that setting a thicker `lineWidth` caused the progress circle to end up partially outside the border. This doesn't look great IMO, and isn't consistent with e.g. the download progress in the Music app. 

This change allows a thicker `lineWidth` value to be used with any `borderWidth` value. As the line width grows, the radius shrinks so that it never ends up partially outside the border. 

It preserves the half-pixel overlap of the original so that a little gap doesn't appear between the border and the progress circle.
