### PR TITLE
Fixed wrong width of value label

### DIFF
--- a/src/Components/MRCircularProgressView.m
+++ b/src/Components/MRCircularProgressView.m
@@ -120,7 +120,7 @@ static NSString *const MRCircularProgressViewProgressAnimationKey = @"MRCircular
     const CGFloat offset = 4;
     CGRect valueLabelRect = self.bounds;
     valueLabelRect.origin.x += offset;
-    valueLabelRect.size.width -= offset;
+    valueLabelRect.size.width -= 2*offset;
     self.valueLabel.frame = valueLabelRect;
     
     self.layer.cornerRadius = self.frame.size.width / 2.0f;


### PR DESCRIPTION
The valueLabel offset of 4px is only applied to the left side of the label. This results in a wrong width and thus wrong alignment. This change adds another 4px offset to the right side of the label.
