### PR TITLE
Don't mess with `NSLocale.currentLocale`

### DIFF
--- a/src/Components/MRNavigationBarProgressView.m
+++ b/src/Components/MRNavigationBarProgressView.m
@@ -50,7 +50,7 @@ static NSString *const MR_UINavigationControllerLastVisibleViewController = @"UI
 
 static NSNumberFormatter *progressNumberFormatter;
 
-+ (void)load {
++ (void)initialize {
     NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
     numberFormatter.numberStyle = NSNumberFormatterPercentStyle;
     numberFormatter.locale = NSLocale.currentLocale;


### PR DESCRIPTION
It might not reflect the user's actual locale in `+load`, so let's do
the set up in `+initialize`.

See also CocoaPods/CocoaPods#2924
