### PR TITLE
Automatic dark mode

### DIFF
--- a/src/Blur/MRBlurView.m
+++ b/src/Blur/MRBlurView.m
@@ -103,6 +103,10 @@
 
 - (void)setPlaceholder {
     self.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.96];
+    
+    if ([UIApplication sharedApplication].statusBarStyle == UIStatusBarStyleLightContent) {
+        self.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.96];
+    }
 }
 
 - (void)clearPlaceholder {
@@ -126,7 +130,11 @@
     }
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        image = [image mr_applyBlurWithRadius:30.0 tintColor:[UIColor colorWithWhite:0.97 alpha:0.82] saturationDeltaFactor:1.0 maskImage:nil];
+        UIColor *defaultBgColor = [UIColor colorWithWhite:0.97 alpha:0.82];
+        if ([UIApplication sharedApplication].statusBarStyle == UIStatusBarStyleLightContent) {
+            defaultBgColor = [UIColor colorWithWhite:0.03 alpha:0.82];
+        }
+        image = [image mr_applyBlurWithRadius:30.0 tintColor:defaultBgColor saturationDeltaFactor:1.0 maskImage:nil];
         dispatch_async(dispatch_get_main_queue(), ^{
             // Fade on content's change, dependent if there was already an image.
             CATransition *transition = [CATransition new];

--- a/src/Components/MRProgressOverlayView.m
+++ b/src/Components/MRProgressOverlayView.m
@@ -196,8 +196,12 @@ static void *MRProgressOverlayViewObservationContext = &MRProgressOverlayViewObs
     // Create titleLabel
     UILabel *titleLabel = [UILabel new];
     self.titleLabel = titleLabel;
+    UIColor *textColor = UIColor.blackColor;
+    if ([UIApplication sharedApplication].statusBarStyle == UIStatusBarStyleLightContent) {
+        textColor = UIColor.whiteColor;
+    }
     self.titleLabel.attributedText = [[NSAttributedString alloc] initWithString:@"Loading ..." attributes:@{
-        NSForegroundColorAttributeName: UIColor.blackColor,
+        NSForegroundColorAttributeName: textColor,
         NSFontAttributeName:            [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline],
         NSKernAttributeName:            NSNull.null,  // turn on auto-kerning
     }];
@@ -566,7 +570,12 @@ static void *MRProgressOverlayViewObservationContext = &MRProgressOverlayViewObs
     
     void(^animBlock)() = ^{
         [self setSubviewTransform:CGAffineTransformIdentity alpha:1.0f];
-        self.backgroundColor = [UIColor colorWithWhite:0 alpha:0.4f];
+        if ([UIApplication sharedApplication].statusBarStyle == UIStatusBarStyleLightContent) {
+            self.backgroundColor = [UIColor colorWithWhite:1 alpha:0.4f];
+        } else {
+            self.backgroundColor = [UIColor colorWithWhite:0 alpha:0.4f];
+        }
+
     };
     
     if (animated) {


### PR DESCRIPTION
I am using MRProgress in several apps. In all apps it seems to be a good idea to choose the same background color like the navigation bar (if one apparent) as the default background color of the progress view. So I changed all default coloring implementation to automatically change to a dark coloring (by simply inverting the colors) when the status bar style is set to `LightContent`.

Maybe you want to consider to integrate this into MRProgress or think about a similar solution. I've read https://github.com/mrackwitz/MRProgress/issues/59 and couldn't find another working solution for a background tint yet. So I came up with this automatic one. Hope you like it.
