### PR TITLE
When using Xcode 6.3 MRNavigationBarProgressView.h, MRCircularProgressVi...

### DIFF
--- a/src/Components/MRCircularProgressView.m
+++ b/src/Components/MRCircularProgressView.m
@@ -29,6 +29,7 @@ static NSString *const MRCircularProgressViewProgressAnimationKey = @"MRCircular
 @implementation MRCircularProgressView {
     int _valueLabelProgressPercentDifference;
 }
+@dynamic progress;
 
 @synthesize stopButton = _stopButton;
 

--- a/src/Components/MRNavigationBarProgressView.m
+++ b/src/Components/MRNavigationBarProgressView.m
@@ -47,6 +47,7 @@ static NSString *const MR_UINavigationControllerLastVisibleViewController = @"UI
 
 
 @implementation MRNavigationBarProgressView
+@dynamic progress;
 
 static NSNumberFormatter *progressNumberFormatter;
 


### PR DESCRIPTION
When using Xcode 6.3 MRNavigationBarProgressView.h, MRCircularProgressView.h generates a compiler warning as follows:

> Auto property synthesis will not synthesize property 'progress'; it will be implemented by its superclass, use @dynamic to acknowledge intention
20d34cf

I've made a pull request #95 20d34cf that seems to take care of the issue by adding the specified @dynamic call in the @implementation, but someone should probably check to make sure that's the correct approach.

But why do you redeclare property on subclass?