### PR TITLE
Allow changing opacity of the background mask as well as hiding it

### DIFF
--- a/src/Components/MRProgressOverlayView.h
+++ b/src/Components/MRProgressOverlayView.h
@@ -191,6 +191,12 @@ typedef NS_ENUM(NSUInteger, MRProgressOverlayViewMode){
  */
 @property (nonatomic, copy) MRProgressOverlayViewStopBlock stopBlock;
 
+/** Setting this value to YES will prevent backgroundColor change when displaying the Overlay */
+@property (nonatomic, assign) BOOL shouldHideBackgroundMask;
+
+/** Background Color Opacity */
+@property (nonatomic, assign) float backgroundMaskOpacity;
+
 /**
  Change the tint color of the mode views.
  

--- a/src/Components/MRProgressOverlayView.m
+++ b/src/Components/MRProgressOverlayView.m
@@ -180,6 +180,9 @@ static void *MRProgressOverlayViewObservationContext = &MRProgressOverlayViewObs
     // Create blurView
     self.blurView = [self createBlurView];
     
+    self.shouldHideBackgroundMask = NO;
+    self.backgroundMaskOpacity = 0.4f;
+    
     // Create container with contents
     UIView *dialogView = [UIView new];
     [self addSubview:dialogView];
@@ -566,7 +569,9 @@ static void *MRProgressOverlayViewObservationContext = &MRProgressOverlayViewObs
     
     void(^animBlock)() = ^{
         [self setSubviewTransform:CGAffineTransformIdentity alpha:1.0f];
-        self.backgroundColor = [UIColor colorWithWhite:0 alpha:0.4f];
+        if (!self.shouldHideBackgroundMask) {
+            self.backgroundColor = [UIColor colorWithWhite:0 alpha:self.backgroundMaskOpacity];
+        }
     };
     
     if (animated) {


### PR DESCRIPTION
In the project that I am working on, we was required to hide - and in some cases change the opacity - the background mask that is displaying below the overlay.

This pull request is adding that funcionality to the main library. 
Hope you can merge it and therefore we will be able to use the official repository instead of the fork.

Thanks! :)