### PR TITLE
Using provided height for custom view mode.

### DIFF
--- a/src/Components/MRProgressOverlayView.m
+++ b/src/Components/MRProgressOverlayView.m
@@ -748,7 +748,11 @@ static void *MRProgressOverlayViewObservationContext = &MRProgressOverlayViewObs
         CGFloat paddingBottom = 0;
         
         if (self.mode != MRProgressOverlayViewModeDeterminateHorizontalBar) {
-            modeViewFrame = CGRectMake(modePadding, y, innerViewWidth, innerViewWidth);
+            if (self.mode == MRProgressOverlayViewModeCustom) {
+                modeViewFrame = CGRectMake(modePadding, y, innerViewWidth, self.modeView.frame.size.height);
+            } else {
+                modeViewFrame = CGRectMake(modePadding, y, innerViewWidth, innerViewWidth);
+            }
             paddingBottom = isTextNonEmpty ? 20 : modePadding;
         } else {
             modeViewFrame = CGRectMake(10, y, dialogWidth-20, 5);


### PR DESCRIPTION
The aim of this change is that, when using CustomMode of MRProgressOverlayView, we want to show custom loading view as provided custom view's size.