### PR TITLE
Use drawViewHierarchyinRect when applicable 

### DIFF
--- a/src/Blur/MRBlurView.m
+++ b/src/Blur/MRBlurView.m
@@ -182,7 +182,11 @@
     CGContextTranslateCTM(context, -origin.x, -origin.y);
     
     // Draw the window
-    [window.layer renderInContext:context];
+    if ([window respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
+        [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:YES];
+    } else {
+        [window.layer renderInContext:context];
+    }
     
     // Capture the image and exit context
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();


### PR DESCRIPTION
This request has 2 purposes:
1) Avoid crashes in iOS 9 when -renderInContext is called at this point
2) Increase performance, when -drawViewHierarchyInRect is available
