### PR TITLE
Fix window crash on iOS 8

### DIFF
--- a/src/Blur/MRBlurView.m
+++ b/src/Blur/MRBlurView.m
@@ -151,7 +151,7 @@
     BOOL wasHidden = self.superview.hidden;
     self.superview.hidden = YES;
     
-    UIWindow *window = UIApplication.sharedApplication.delegate.window;
+    UIWindow *window = self.window;
     
     // Absolute origin of receiver
     CGPoint origin = self.bounds.origin;


### PR DESCRIPTION
On iOS 8, `[window.layer renderInContext:context];` (line 185 of this file) will cause a crash if the window that the progress view is in is not the application delegates window. By using `self.window`, this crash has been fixed. 

This doesn't occur on iOS 9, but it seems that CGContext is much more picky on iOS 8. 
