### PR TITLE
Added Framework for Carthage compatiblity

### DIFF
--- a/MRProgress iOS/Info.plist
+++ b/MRProgress iOS/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/MRProgress iOS/MRProgressiOS.h
+++ b/MRProgress iOS/MRProgressiOS.h
@@ -1,0 +1,32 @@
+//
+//  MRProgress iOS.h
+//  MRProgress iOS
+//
+//  Created by Martin Puza on 04.11.15.
+//  Copyright © 2015 Marius Rackwitz. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for MRProgress iOS.
+FOUNDATION_EXPORT double MRProgress_iOSVersionNumber;
+
+//! Project version string for MRProgress iOS.
+FOUNDATION_EXPORT const unsigned char MRProgress_iOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <MRProgress_iOS/PublicHeader.h>
+
+
+#import "MRActivityIndicatorView.h"
+#import "MRBlurView.h"
+#import "UIImage+MRImageEffects.h"
+#import "MRCircularProgressView.h"
+#import "MRIconView.h"
+#import "MRMessageInterceptor.h"
+#import "MRNavigationBarProgressView.h"
+#import "MRProgressOverlayView.h"
+#import "MRWeakProxy.h"
+
+#import "MRMethodCopier.h"
+#import "MRProgressHelper.h"
+#import "MRStopButton.h"

--- a/MRProgress iOSTests/Info.plist
+++ b/MRProgress iOSTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/MRProgress iOSTests/MRProgress_iOSTests.swift
+++ b/MRProgress iOSTests/MRProgress_iOSTests.swift
@@ -1,0 +1,36 @@
+//
+//  MRProgress_iOSTests.swift
+//  MRProgress iOSTests
+//
+//  Created by Martin Puza on 04.11.15.
+//  Copyright © 2015 Marius Rackwitz. All rights reserved.
+//
+
+import XCTest
+@testable import MRProgress_iOS
+
+class MRProgress_iOSTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/MRProgress.xcodeproj/project.pbxproj
+++ b/MRProgress.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		21F7F2791BEA288400ACE9C5 /* MRWeakProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD5AB1817353E00654750 /* MRWeakProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21F7F27A1BEA288400ACE9C5 /* MRMethodCopier.h in Headers */ = {isa = PBXBuildFile; fileRef = 717B67D3193A2CC100829442 /* MRMethodCopier.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21F7F27C1BEA2A4300ACE9C5 /* MRProgressiOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 21B8503C1BEA27B60096A584 /* MRProgressiOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21FB7B7D1D86E59F0067E530 /* MRStopableView.h in Headers */ = {isa = PBXBuildFile; fileRef = 299730941881CB520022B27B /* MRStopableView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29CE9679186E0129006006B0 /* MRStopButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 29CE9677186E0129006006B0 /* MRStopButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29CE967A186E0129006006B0 /* MRStopButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 29CE9678186E0129006006B0 /* MRStopButton.m */; };
 		710BD58B1816AD3700654750 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 710BD58A1816AD3700654750 /* QuartzCore.framework */; };
@@ -342,6 +343,7 @@
 				21F7F2781BEA288400ACE9C5 /* MRProgressHelper.h in Headers */,
 				21F7F2711BEA288400ACE9C5 /* MRIconView.h in Headers */,
 				21F7F2771BEA288400ACE9C5 /* MRMessageInterceptor.h in Headers */,
+				21FB7B7D1D86E59F0067E530 /* MRStopableView.h in Headers */,
 				21F7F2721BEA288400ACE9C5 /* MRNavigationBarProgressView.h in Headers */,
 				21F7F2791BEA288400ACE9C5 /* MRWeakProxy.h in Headers */,
 				21F7F2761BEA288400ACE9C5 /* MRStopButton.h in Headers */,

--- a/MRProgress.xcodeproj/project.pbxproj
+++ b/MRProgress.xcodeproj/project.pbxproj
@@ -8,6 +8,34 @@
 
 /* Begin PBXBuildFile section */
 		1594464BC6BF48A88B7F9A6B /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7AF019C9ADBE4EEA962ED766 /* libPods.a */; };
+		21B850441BEA27B60096A584 /* MRProgressiOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21B8503A1BEA27B60096A584 /* MRProgressiOS.framework */; };
+		21B850491BEA27B60096A584 /* MRProgress_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B850481BEA27B60096A584 /* MRProgress_iOSTests.swift */; };
+		21B850511BEA27E20096A584 /* MRBlurView.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD5971817353E00654750 /* MRBlurView.m */; };
+		21B850521BEA28080096A584 /* MRMessageInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD5A91817353E00654750 /* MRMessageInterceptor.m */; };
+		21B850531BEA280C0096A584 /* MRWeakProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD5AC1817353E00654750 /* MRWeakProxy.m */; };
+		21B850541BEA28120096A584 /* MRNavigationBarProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD5A41817353E00654750 /* MRNavigationBarProgressView.m */; };
+		21F7F2651BEA286000ACE9C5 /* UIImage+MRImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD5991817353E00654750 /* UIImage+MRImageEffects.m */; };
+		21F7F2661BEA286000ACE9C5 /* MRActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD59C1817353E00654750 /* MRActivityIndicatorView.m */; };
+		21F7F2671BEA286000ACE9C5 /* MRCircularProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD59E1817353E00654750 /* MRCircularProgressView.m */; };
+		21F7F2681BEA286000ACE9C5 /* MRIconView.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD5A01817353E00654750 /* MRIconView.m */; };
+		21F7F2691BEA286000ACE9C5 /* MRProgressOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 710BD5A61817353E00654750 /* MRProgressOverlayView.m */; };
+		21F7F26A1BEA286000ACE9C5 /* MRProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = 717B67D8193A813300829442 /* MRProgressView.m */; };
+		21F7F26B1BEA286000ACE9C5 /* MRStopButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 29CE9678186E0129006006B0 /* MRStopButton.m */; };
+		21F7F26C1BEA286000ACE9C5 /* MRMethodCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 717B67D4193A2CC100829442 /* MRMethodCopier.m */; };
+		21F7F26D1BEA288400ACE9C5 /* MRBlurView.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD5961817353E00654750 /* MRBlurView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F26E1BEA288400ACE9C5 /* UIImage+MRImageEffects.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD5981817353E00654750 /* UIImage+MRImageEffects.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F26F1BEA288400ACE9C5 /* MRActivityIndicatorView.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD59B1817353E00654750 /* MRActivityIndicatorView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2701BEA288400ACE9C5 /* MRCircularProgressView.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD59D1817353E00654750 /* MRCircularProgressView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2711BEA288400ACE9C5 /* MRIconView.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD59F1817353E00654750 /* MRIconView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2721BEA288400ACE9C5 /* MRNavigationBarProgressView.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD5A31817353E00654750 /* MRNavigationBarProgressView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2731BEA288400ACE9C5 /* MRProgressOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD5A51817353E00654750 /* MRProgressOverlayView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2741BEA288400ACE9C5 /* MRProgressView.h in Headers */ = {isa = PBXBuildFile; fileRef = 717B67D7193A813300829442 /* MRProgressView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2761BEA288400ACE9C5 /* MRStopButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 29CE9677186E0129006006B0 /* MRStopButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2771BEA288400ACE9C5 /* MRMessageInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD5A81817353E00654750 /* MRMessageInterceptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2781BEA288400ACE9C5 /* MRProgressHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD5AA1817353E00654750 /* MRProgressHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F2791BEA288400ACE9C5 /* MRWeakProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 710BD5AB1817353E00654750 /* MRWeakProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F27A1BEA288400ACE9C5 /* MRMethodCopier.h in Headers */ = {isa = PBXBuildFile; fileRef = 717B67D3193A2CC100829442 /* MRMethodCopier.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F7F27C1BEA2A4300ACE9C5 /* MRProgressiOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 21B8503C1BEA27B60096A584 /* MRProgressiOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29CE9679186E0129006006B0 /* MRStopButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 29CE9677186E0129006006B0 /* MRStopButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29CE967A186E0129006006B0 /* MRStopButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 29CE9678186E0129006006B0 /* MRStopButton.m */; };
 		710BD58B1816AD3700654750 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 710BD58A1816AD3700654750 /* QuartzCore.framework */; };
@@ -44,7 +72,23 @@
 		7197CF191816AA9A0022A19D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7197CF181816AA9A0022A19D /* UIKit.framework */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		21B850451BEA27B60096A584 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7197CEAF18169F210022A19D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 21B850391BEA27B60096A584;
+			remoteInfo = "MRProgress iOS";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		21B8503A1BEA27B60096A584 /* MRProgressiOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MRProgressiOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		21B8503C1BEA27B60096A584 /* MRProgressiOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MRProgressiOS.h; sourceTree = "<group>"; };
+		21B8503E1BEA27B60096A584 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		21B850431BEA27B60096A584 /* MRProgress iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MRProgress iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		21B850481BEA27B60096A584 /* MRProgress_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MRProgress_iOSTests.swift; sourceTree = "<group>"; };
+		21B8504A1BEA27B60096A584 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		299730941881CB520022B27B /* MRStopableView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MRStopableView.h; sourceTree = "<group>"; };
 		29CE9677186E0129006006B0 /* MRStopButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MRStopButton.h; sourceTree = "<group>"; };
 		29CE9678186E0129006006B0 /* MRStopButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MRStopButton.m; sourceTree = "<group>"; };
@@ -92,6 +136,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		21B850361BEA27B60096A584 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		21B850401BEA27B60096A584 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				21B850441BEA27B60096A584 /* MRProgressiOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7197CEB418169F210022A19D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -108,6 +167,26 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		21B8503B1BEA27B60096A584 /* MRProgressiOS */ = {
+			isa = PBXGroup;
+			children = (
+				21B8503C1BEA27B60096A584 /* MRProgressiOS.h */,
+				21B8503E1BEA27B60096A584 /* Info.plist */,
+			);
+			name = MRProgressiOS;
+			path = "MRProgress iOS";
+			sourceTree = "<group>";
+		};
+		21B850471BEA27B60096A584 /* MRProgressiOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				21B850481BEA27B60096A584 /* MRProgress_iOSTests.swift */,
+				21B8504A1BEA27B60096A584 /* Info.plist */,
+			);
+			name = MRProgressiOSTests;
+			path = "MRProgress iOSTests";
+			sourceTree = "<group>";
+		};
 		710BD5951817353E00654750 /* Blur */ = {
 			isa = PBXGroup;
 			children = (
@@ -181,6 +260,8 @@
 			children = (
 				7197CEF418169F470022A19D /* src */,
 				7197CEBC18169F210022A19D /* MRProgress */,
+				21B8503B1BEA27B60096A584 /* MRProgressiOS */,
+				21B850471BEA27B60096A584 /* MRProgressiOSTests */,
 				7197CEB918169F210022A19D /* Frameworks */,
 				7197CEB818169F210022A19D /* Products */,
 				711417411976ED7F005A1DAD /* MRProgress.podspec */,
@@ -192,6 +273,8 @@
 			isa = PBXGroup;
 			children = (
 				7197CEB718169F210022A19D /* libMRProgress.a */,
+				21B8503A1BEA27B60096A584 /* MRProgressiOS.framework */,
+				21B850431BEA27B60096A584 /* MRProgress iOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -249,10 +332,32 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		21B850371BEA27B60096A584 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				21F7F27C1BEA2A4300ACE9C5 /* MRProgressiOS.h in Headers */,
+				21F7F26E1BEA288400ACE9C5 /* UIImage+MRImageEffects.h in Headers */,
+				21F7F26D1BEA288400ACE9C5 /* MRBlurView.h in Headers */,
+				21F7F2781BEA288400ACE9C5 /* MRProgressHelper.h in Headers */,
+				21F7F2711BEA288400ACE9C5 /* MRIconView.h in Headers */,
+				21F7F2771BEA288400ACE9C5 /* MRMessageInterceptor.h in Headers */,
+				21F7F2721BEA288400ACE9C5 /* MRNavigationBarProgressView.h in Headers */,
+				21F7F2791BEA288400ACE9C5 /* MRWeakProxy.h in Headers */,
+				21F7F2761BEA288400ACE9C5 /* MRStopButton.h in Headers */,
+				21F7F2701BEA288400ACE9C5 /* MRCircularProgressView.h in Headers */,
+				21F7F26F1BEA288400ACE9C5 /* MRActivityIndicatorView.h in Headers */,
+				21F7F2731BEA288400ACE9C5 /* MRProgressOverlayView.h in Headers */,
+				21F7F27A1BEA288400ACE9C5 /* MRMethodCopier.h in Headers */,
+				21F7F2741BEA288400ACE9C5 /* MRProgressView.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7197CEF91816A1750022A19D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7197CF011816A1A10022A19D /* MRProgress.h in Headers */,
 				710BD5AF1817353E00654750 /* UIImage+MRImageEffects.h in Headers */,
 				710BD5AD1817353E00654750 /* MRBlurView.h in Headers */,
 				710BD5BF1817353E00654750 /* MRProgressHelper.h in Headers */,
@@ -265,7 +370,6 @@
 				717B67D9193A813300829442 /* MRProgressView.h in Headers */,
 				710BD5B31817353E00654750 /* MRCircularProgressView.h in Headers */,
 				710BD5B11817353E00654750 /* MRActivityIndicatorView.h in Headers */,
-				7197CF011816A1A10022A19D /* MRProgress.h in Headers */,
 				710BD5BB1817353E00654750 /* MRProgressOverlayView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -273,6 +377,40 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		21B850391BEA27B60096A584 /* MRProgressiOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 21B8504F1BEA27B60096A584 /* Build configuration list for PBXNativeTarget "MRProgressiOS" */;
+			buildPhases = (
+				21B850351BEA27B60096A584 /* Sources */,
+				21B850361BEA27B60096A584 /* Frameworks */,
+				21B850371BEA27B60096A584 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MRProgressiOS;
+			productName = "MRProgress iOS";
+			productReference = 21B8503A1BEA27B60096A584 /* MRProgressiOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		21B850421BEA27B60096A584 /* MRProgress iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 21B850501BEA27B60096A584 /* Build configuration list for PBXNativeTarget "MRProgress iOSTests" */;
+			buildPhases = (
+				21B8503F1BEA27B60096A584 /* Sources */,
+				21B850401BEA27B60096A584 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				21B850461BEA27B60096A584 /* PBXTargetDependency */,
+			);
+			name = "MRProgress iOSTests";
+			productName = "MRProgress iOSTests";
+			productReference = 21B850431BEA27B60096A584 /* MRProgress iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		7197CEB618169F210022A19D /* MRProgress */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7197CEDA18169F210022A19D /* Build configuration list for PBXNativeTarget "MRProgress" */;
@@ -298,8 +436,19 @@
 		7197CEAF18169F210022A19D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastSwiftUpdateCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Marius Rackwitz";
+				TargetAttributes = {
+					21B850391BEA27B60096A584 = {
+						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
+					};
+					21B850421BEA27B60096A584 = {
+						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 7197CEB218169F210022A19D /* Build configuration list for PBXProject "MRProgress" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -314,6 +463,8 @@
 			projectRoot = "";
 			targets = (
 				7197CEB618169F210022A19D /* MRProgress */,
+				21B850391BEA27B60096A584 /* MRProgressiOS */,
+				21B850421BEA27B60096A584 /* MRProgress iOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -352,6 +503,33 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		21B850351BEA27B60096A584 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				21B850511BEA27E20096A584 /* MRBlurView.m in Sources */,
+				21F7F2651BEA286000ACE9C5 /* UIImage+MRImageEffects.m in Sources */,
+				21F7F2661BEA286000ACE9C5 /* MRActivityIndicatorView.m in Sources */,
+				21F7F2671BEA286000ACE9C5 /* MRCircularProgressView.m in Sources */,
+				21F7F2681BEA286000ACE9C5 /* MRIconView.m in Sources */,
+				21B850541BEA28120096A584 /* MRNavigationBarProgressView.m in Sources */,
+				21F7F2691BEA286000ACE9C5 /* MRProgressOverlayView.m in Sources */,
+				21F7F26A1BEA286000ACE9C5 /* MRProgressView.m in Sources */,
+				21F7F26B1BEA286000ACE9C5 /* MRStopButton.m in Sources */,
+				21B850521BEA28080096A584 /* MRMessageInterceptor.m in Sources */,
+				21B850531BEA280C0096A584 /* MRWeakProxy.m in Sources */,
+				21F7F26C1BEA286000ACE9C5 /* MRMethodCopier.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		21B8503F1BEA27B60096A584 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				21B850491BEA27B60096A584 /* MRProgress_iOSTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7197CEB318169F210022A19D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -376,7 +554,125 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		21B850461BEA27B60096A584 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 21B850391BEA27B60096A584 /* MRProgressiOS */;
+			targetProxy = 21B850451BEA27B60096A584 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		21B8504B1BEA27B60096A584 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "MRProgress iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mrackwitz.MRProgress-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		21B8504C1BEA27B60096A584 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "MRProgress iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mrackwitz.MRProgress-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		21B8504D1BEA27B60096A584 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "MRProgress iOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mrackwitz.MRProgress-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		21B8504E1BEA27B60096A584 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "MRProgress iOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mrackwitz.MRProgress-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
 		7197CED818169F210022A19D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -390,13 +686,18 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -409,7 +710,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -428,20 +729,26 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -499,6 +806,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		21B8504F1BEA27B60096A584 /* Build configuration list for PBXNativeTarget "MRProgressiOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				21B8504B1BEA27B60096A584 /* Debug */,
+				21B8504C1BEA27B60096A584 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		21B850501BEA27B60096A584 /* Build configuration list for PBXNativeTarget "MRProgress iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				21B8504D1BEA27B60096A584 /* Debug */,
+				21B8504E1BEA27B60096A584 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7197CEB218169F210022A19D /* Build configuration list for PBXProject "MRProgress" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/MRProgress.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MRProgress.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MRProgress.xcodeproj/xcshareddata/xcschemes/MRProgress iOS.xcscheme
+++ b/MRProgress.xcodeproj/xcshareddata/xcschemes/MRProgress iOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "21B850391BEA27B60096A584"
+               BuildableName = "MRProgressiOS.framework"
+               BlueprintName = "MRProgressiOS"
+               ReferencedContainer = "container:MRProgress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "21B850421BEA27B60096A584"
+               BuildableName = "MRProgress iOSTests.xctest"
+               BlueprintName = "MRProgress iOSTests"
+               ReferencedContainer = "container:MRProgress.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "21B850391BEA27B60096A584"
+            BuildableName = "MRProgressiOS.framework"
+            BlueprintName = "MRProgressiOS"
+            ReferencedContainer = "container:MRProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "21B850391BEA27B60096A584"
+            BuildableName = "MRProgressiOS.framework"
+            BlueprintName = "MRProgressiOS"
+            ReferencedContainer = "container:MRProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "21B850391BEA27B60096A584"
+            BuildableName = "MRProgressiOS.framework"
+            BlueprintName = "MRProgressiOS"
+            ReferencedContainer = "container:MRProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MRProgress.xcodeproj/xcshareddata/xcschemes/MRProgress.xcscheme
+++ b/MRProgress.xcodeproj/xcshareddata/xcschemes/MRProgress.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7197CEB618169F210022A19D"
+               BuildableName = "libMRProgress.a"
+               BlueprintName = "MRProgress"
+               ReferencedContainer = "container:MRProgress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7197CEB618169F210022A19D"
+            BuildableName = "libMRProgress.a"
+            BlueprintName = "MRProgress"
+            ReferencedContainer = "container:MRProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7197CEB618169F210022A19D"
+            BuildableName = "libMRProgress.a"
+            BlueprintName = "MRProgress"
+            ReferencedContainer = "container:MRProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/Components/MRCircularProgressView.h
+++ b/src/Components/MRCircularProgressView.h
@@ -14,7 +14,7 @@
 /**
  You use the MRCircularProgressView class to depict the progress of a task over time.
  */
-@interface MRCircularProgressView : MRProgressView<MRStopableView>
+@interface MRCircularProgressView : MRProgressView<MRStopableView, CAAnimationDelegate>
 
 /**
  Value label.


### PR DESCRIPTION
I added a framework target, so MRProgress can be used in Carthage.
The MRStopableView seems to be unused in the static library, but needed in the framework?
There's also a warning in the most recent XCode that I hopefully fixed.
