### PR TITLE
Set accessibilityIdentifier to dialogView in MRProgressOverlayView

### DIFF
--- a/src/Components/MRProgressOverlayView.m
+++ b/src/Components/MRProgressOverlayView.m
@@ -192,7 +192,8 @@ static void *MRProgressOverlayViewObservationContext = &MRProgressOverlayViewObs
     dialogView.layer.shadowRadius = cornerRadius + 5;
     dialogView.layer.shadowOpacity = 0.1f;
     dialogView.layer.shadowOffset = CGSizeMake(-(cornerRadius+5)/2.0f, -(cornerRadius+5)/2.0f);
-    
+    dialogView.accessibilityIdentifier = @"MRProgressOverlayView";
+
     // Create titleLabel
     UILabel *titleLabel = [UILabel new];
     self.titleLabel = titleLabel;


### PR DESCRIPTION
I want to wait for MRProgressOverlayView to dismiss. If this pull request is merged, I can write follows to do so.

```swift
let app = XCUIApplication()
let overlayView = app.otherElements["MRProgressOverlayView"]
let exists = NSPredicate(format: "exists == false")
expectation(for: exists, evaluatedWith: overlayView, handler: nil)
waitForExpectations(timeout: 10, handler: nil)
```